### PR TITLE
Drawers and Bones

### DIFF
--- a/kubejs/server_scripts/functionalstorage-tempfix.js
+++ b/kubejs/server_scripts/functionalstorage-tempfix.js
@@ -1,0 +1,5 @@
+ServerEvents.recipes(event => {
+    event.remove({id: 'functionalstorage:oak_drawer_alternate_x1'})
+    event.remove({id: 'functionalstorage:oak_drawer_alternate_x2'})
+    event.remove({id: 'functionalstorage:oak_drawer_alternate_x4'})
+  }) //Remove's currently bugged functional storage drawers for modded woods. Use framed drawers instead.

--- a/kubejs/server_scripts/mutant-parts.js
+++ b/kubejs/server_scripts/mutant-parts.js
@@ -1,0 +1,7 @@
+ServerEvents.recipes(event => {
+    event.shapeless('4x minecraft:bone_meal', ['mutantmonsters:mutant_skeleton_limb',])
+    event.shapeless('6x minecraft:bone_meal', ['mutantmonsters:mutant_skeleton_pelvis'])
+    event.shapeless('2x minecraft:bone_meal', ['mutantmonsters:mutant_skeleton_rib'])
+    event.shapeless('10x minecraft:bone_meal', ['mutantmonsters:mutant_skeleton_skull'])
+    event.shapeless('4x minecraft:leather', ['mutantmonsters:mutant_skeleton_shoulder_pad'])
+})


### PR DESCRIPTION
Adds recipes for Mutant Skeleton parts to be made into bonemeal/leather, and removes the alternate recipes for storage drawers due to a bugged recipe.